### PR TITLE
Added support for empty components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -181,10 +181,10 @@ export default Selector(selector => {
         }
 
         function getComponentForDOMNode (el) {
-            if (!el || el.nodeType !== 1)
+            if (!el || el.nodeType !== 1 || el.nodeType !== 8)
                 return null;
 
-            const isRootNode = el.hasAttribute('data-reactroot');
+            const isRootNode = el.hasAttribute && el.hasAttribute('data-reactroot');
 
             for (var prop of Object.keys(el)) {
                 if (!/^__reactInternalInstance/.test(prop))

--- a/src/index.js
+++ b/src/index.js
@@ -181,7 +181,7 @@ export default Selector(selector => {
         }
 
         function getComponentForDOMNode (el) {
-            if (!el || el.nodeType !== 1 || el.nodeType !== 8)
+            if (!el || !(el.nodeType === 1 || el.nodeType === 8))
                 return null;
 
             const isRootNode = el.hasAttribute && el.hasAttribute('data-reactroot');

--- a/test/data/src/app.jsx
+++ b/test/data/src/app.jsx
@@ -57,6 +57,21 @@ class WrapperComponent extends React.Component {
     }
 }
 
+class EmptyComponent extends React.Component {
+    constructor () {
+        super();
+
+        this.state = {
+            id:   1,
+            text: null
+        };
+    }
+
+    render () {
+        return this.state.text;
+    }
+}
+
 class App extends React.Component {
     constructor () {
         super();
@@ -77,6 +92,7 @@ class App extends React.Component {
                     </div>
                 </div>
                 <WrapperComponent direction="horizontal"/>
+                <EmptyComponent />
             </div>
         );
     }

--- a/test/react-plugin-test.js
+++ b/test/react-plugin-test.js
@@ -131,3 +131,9 @@ test('Should get props and state from components with common DOM node - Regressi
         }))
         .eql({ color: '#fff', text: 'Component inside of wrapper component' });
 });
+
+test('Should get the component with empty output', async t => {
+    const component = await ReactSelector('EmptyComponent');
+
+    await t.expect(component.getReact(({ state }) => state.id)).eql(1);
+});


### PR DESCRIPTION
When React component returns an empty output (e.g. portals), it renders itself into an empty comment node, e.g. `<!-- react-empty: 11 -->`. This comment node has a valid react component instance attached to it and there is no problem getting it.