### PR TITLE
Added ability to select by props to selectors using square bracket notation

### DIFF
--- a/src/react-15/index.js
+++ b/src/react-15/index.js
@@ -64,16 +64,54 @@ function reactSelector15 (selector) {
     }
 
     function parseSelectorElements (compositeSelector) {
-        return compositeSelector
-            .split(' ')
+        const compositeSelectorTrimmed = compositeSelector.trim();
+        const elements = [];
+        let numSquareBrackets = 0;
+        let elementName = '';
+
+        for (let i = 0; i < compositeSelectorTrimmed.length; i++) {
+            const c = compositeSelectorTrimmed[i];
+
+            if (c === '[')
+                numSquareBrackets++;
+
+            if (c === ']')
+                numSquareBrackets--;
+
+            // If there's a space, we've reached the end of an element name which means
+            //  we should push the element name to the list of elements
+            if (c === ' ') {
+                if (numSquareBrackets === 0) {
+                    elements.push(elementName);
+                    elementName = '';
+                    numSquareBrackets = 0;
+                    continue;
+                }
+            }
+
+            elementName += c;
+        }
+
+        // Push the last element since there's no space to trigger the push above
+        elements.push(elementName);
+
+        return elements
             .filter(el => !!el)
             .map(el => {
                 const attributePairs = el.match(/\[.+?\]/g, () => {}) || [];
                 const name = el.replace(/\[.+?\]/g, '').trim();
                 const attributes = attributePairs.map((attribute) => {
-                    const attributeKeyValuePair = attribute.substr(1, attribute.length - 2).split('=');
-                    const attributeName = attributeKeyValuePair[0];
-                    const attributeValue = attributeKeyValuePair[1];
+                    const attributeKeyValuePair = attribute.substr(1, attribute.length - 2);
+                    const attributeName = attributeKeyValuePair.substr(0, attributeKeyValuePair.indexOf('='));
+                    let attributeValue = attributeKeyValuePair.substr(attributeKeyValuePair.indexOf('=') + 1);
+
+                    // Strip out quotation marks
+                    if (
+                        (attributeValue[0] === '"' || attributeValue[0] === '\'') &&
+                        (attributeValue[attributeValue.length - 1] === '"' || attributeValue[attributeValue.length - 1] === '\'')
+                    )
+                        attributeValue = attributeValue.substr(1, attributeValue.length - 2);
+
 
                     return {
                         name:  attributeName,

--- a/src/react-16/index.js
+++ b/src/react-16/index.js
@@ -70,16 +70,54 @@ function react16Selector (selector) {
     }
 
     function parseSelectorElements (compositeSelector) {
-        return compositeSelector
-            .split(' ')
+        const compositeSelectorTrimmed = compositeSelector.trim();
+        const elements = [];
+        let numSquareBrackets = 0;
+        let elementName = '';
+
+        for (let i = 0; i < compositeSelectorTrimmed.length; i++) {
+            const c = compositeSelectorTrimmed[i];
+
+            if (c === '[')
+                numSquareBrackets++;
+
+            if (c === ']')
+                numSquareBrackets--;
+
+            // If there's a space, we've reached the end of an element name which means
+            //  we should push the element name to the list of elements
+            if (c === ' ') {
+                if (numSquareBrackets === 0) {
+                    elements.push(elementName);
+                    elementName = '';
+                    numSquareBrackets = 0;
+                    continue;
+                }
+            }
+
+            elementName += c;
+        }
+
+        // Push the last element since there's no space to trigger the push above
+        elements.push(elementName);
+
+        return elements
             .filter(el => !!el)
             .map(el => {
                 const attributePairs = el.match(/\[.+?\]/g, () => {}) || [];
                 const name = el.replace(/\[.+?\]/g, '').trim();
                 const attributes = attributePairs.map((attribute) => {
-                    const attributeKeyValuePair = attribute.substr(1, attribute.length - 2).split('=');
-                    const attributeName = attributeKeyValuePair[0];
-                    const attributeValue = attributeKeyValuePair[1];
+                    const attributeKeyValuePair = attribute.substr(1, attribute.length - 2);
+                    const attributeName = attributeKeyValuePair.substr(0, attributeKeyValuePair.indexOf('='));
+                    let attributeValue = attributeKeyValuePair.substr(attributeKeyValuePair.indexOf('=') + 1);
+
+                    // Strip out quotation marks
+                    if (
+                        (attributeValue[0] === '"' || attributeValue[0] === '\'') &&
+                        (attributeValue[attributeValue.length - 1] === '"' || attributeValue[attributeValue.length - 1] === '\'')
+                    )
+                        attributeValue = attributeValue.substr(1, attributeValue.length - 2);
+
 
                     return {
                         name:  attributeName,

--- a/test/fixtures/common-tests.js
+++ b/test/fixtures/common-tests.js
@@ -13,6 +13,14 @@ for (const version of SUPPORTED_VERSIONS) {
             await loadApp(version);
         });
 
+    test('Should find the wrapper component where the `direction` attribute is equal to `horizontal`', async t => {
+        await t.expect(ReactSelector('WrapperComponent[direction=horizontal]').exists).ok();
+    });
+
+    test('Should not find a wrapper component where the `direction` attribute is equal to `vertical`', async t => {
+        await t.expect(ReactSelector('WrapperComponent[direction=vertical]').exists).notOk();
+    });
+
     test(`Should throw exception for non-valid selectors`, async t => {
         for (var selector of [null, false, void 0, {}, 42]) {
             try {


### PR DESCRIPTION
This PR addresses a need I had to select React components by their props as well as by their names. There are some cases where the only difference between two components of the same type is a prop. It should now allow you to select elements using their props, using square brackets similar to CSS attribute selectors.

e.g.

`this.email = ReactSelector('Field[name=email] TextField')`
`this.password = ReactSelector('Field[name=password] TextField')`

If this seems like a good idea I'll add some more tests but I wanted the OK first. I'm also wondering if I need to make changes to `getReact` after this change? Specifically I was wondering about `getComponentInstance` within `getReact`.  I wasn't quite sure how it worked.