### PR TITLE
Fix type definition file path

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
   "peerDependencies": {
     "testcafe": "*"
   },
-  "types": "ts-defs/index.d.ts"
+  "types": "./ts-defs/index.d.ts"
 }


### PR DESCRIPTION
When I tried

```typescript
import ReactSelector from 'testcafe-react-selectors';
```

I got

![screen shot 2018-02-27 at 7 10 22 pm](https://user-images.githubusercontent.com/431442/36725646-e8661658-1bf1-11e8-924a-aee140ad7583.png)

Looking at https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html I noticed that the `types` path started with `./` so I tried that. Built the library and did `yarn add file:/path/to/testcafe-react-selectors` and the error went away.

Please let me know if I did something wrong as I couldn't find a contributing guideline on the repo and this is my first time sending a PR to an OSS project. Thank you!

