### PR TITLE
add waitForReact helper

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -51,7 +51,9 @@ gulp.task('build-selectors-script', ['clean', 'lint'], function () {
             selectorReact16: fs.readFileSync('./src/react-16/index.js').toString(),
 
             getReactReact15: fs.readFileSync('./src/react-15/get-react.js').toString(),
-            getReactReact16: fs.readFileSync('./src/react-16/get-react.js').toString()
+            getReactReact16: fs.readFileSync('./src/react-16/get-react.js').toString(),
+
+            waitForReact: fs.readFileSync('./src/wait-for-react.js').toString()
         }))
         .pipe(rename('index.js'))
         .pipe(gulp.dest('lib/tmp'));

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Suppose you have the following JSX.
 To get a root DOM element for a component, pass the component name to the `ReactSelector` constructor.
 
 ```js
-import ReactSelector from 'testcafe-react-selectors';
+import { ReactSelector } from 'testcafe-react-selectors';
 
 const todoInput = ReactSelector('TodoInput');
 ```
@@ -50,7 +50,7 @@ Warning: if you specify a DOM element’s tag name, React selectors search for t
 Selectors returned by ReactSelector( selector ) are recognized as TestCafe selectors. You can combine them with regular selectors and filter with `.withText`, `.nth`, `.find` and [other](http://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors.html#functional-style-selectors) functions. To search for elements within a component, you can use the following combined approach.
 
 ```js
-import ReactSelector from 'testcafe-react-selectors';
+import { ReactSelector } from 'testcafe-react-selectors';
 
 var itemsCount = ReactSelector('TodoApp').find('.items-count span');
 ```
@@ -58,7 +58,7 @@ var itemsCount = ReactSelector('TodoApp').find('.items-count span');
 Let’s use the API described above to add a task to a Todo list and check that the number of items changed.
 
 ```js
-import ReactSelector from 'testcafe-react-selectors';
+import { ReactSelector } from 'testcafe-react-selectors';
 
 fixture `TODO list test`
 	.page('http://localhost:1337');
@@ -71,6 +71,27 @@ test('Add new task', async t => {
         .typeText(todoTextInput, 'My Item')
         .pressKey('enter')
         .expect(todoItem.count).eql(3);
+});
+```
+
+#### Usage with server-side rendering (SSR)
+
+When doing SSR, e.g. with [next.js](https://github.com/zeit/next.js/) bootstrapping and re-hydration 
+of react sometimes takes longer and `ReactSelector` would run even before react is ready. Use 
+`waitForReact` helper to wait until react is fully bootstrapped. 
+
+```js
+import { ReactSelector, waitForReact } from 'testcafe-react-selectors';
+
+fixture `Server rendering`
+    .page `http://localhost:1355/serverRender`
+    .beforeEach(async () => {
+        await waitForReact({ selectReactRoot: () => document.querySelector('#__next') });
+    });
+
+test('Should get component inside server rendered root node', async t => {
+    const labelText = ReactSelector('Label').getReact(({ state }) => state.text);
+    await t.expect(labelText).eql('Label Text...');
 });
 ```
 
@@ -99,7 +120,7 @@ The returned client function can be passed to assertions activating the [Smart A
 Example
 
 ```js
-import ReactSelector from 'testcafe-react-selectors';
+import { ReactSelector } from 'testcafe-react-selectors';
 
 fixture `TODO list test`
 	.page('http://localhost:1337');
@@ -121,7 +142,7 @@ ReactSelector('Component').getReact(({ props, state }) => {...})
 Example
 
 ```js
-import ReactSelector from 'testcafe-react-selectors';
+import { ReactSelector } from 'testcafe-react-selectors';
 
 fixture `TODO list test`
     .page('http://localhost:1337');

--- a/src/index.js.mustache
+++ b/src/index.js.mustache
@@ -1,7 +1,12 @@
 /*global document window*/
-var Selector = require('testcafe').Selector;
+var testcafe = require('testcafe');
+var Selector = testcafe.Selector;
+var ClientFunction = testcafe.ClientFunction;
 
-export default Selector(selector => {
+
+const waitForReact = ClientFunction({{{waitForReact}}});
+
+const ReactSelector = Selector(selector => {
     const getRootElsReact15 = {{{getRootElsReact15}}}
     const getRootElsReact16 = {{{getRootElsReact16}}}
     const selectorReact15 = {{{selectorReact15}}}
@@ -55,3 +60,5 @@ export default Selector(selector => {
             return getReactReact16(node, fn);
     }
 });
+
+export { waitForReact, ReactSelector };

--- a/src/wait-for-react.js
+++ b/src/wait-for-react.js
@@ -1,0 +1,40 @@
+/*global Promise, window*/
+
+/*eslint-disable no-unused-vars*/
+function waitForReact ({ waitTimeout, selectReactRoot } = {}) {
+    return new Promise((resolve, reject) => {
+        let pingIntervalId = null;
+        let pingTimeoutId = null;
+        const WAIT_TIMEOUT = waitTimeout || 10000;
+        const PING_INTERVAL = 100;
+
+        const clearTimeouts = () => {
+            window.clearTimeout(pingTimeoutId);
+            window.clearInterval(pingIntervalId);
+        };
+
+        const isThereReact = () => {
+            if (typeof selectReactRoot === 'function') {
+                const root = selectReactRoot() || {};
+
+                return !!root._reactRootContainer;
+            }
+            return false;
+        };
+
+        const check = () => {
+            if (isThereReact()) {
+                clearTimeouts();
+                resolve();
+            }
+        };
+
+        pingTimeoutId = window.setTimeout(() => {
+            clearTimeouts();
+            reject(new Error('Cannot find React.'));
+        }, WAIT_TIMEOUT);
+
+        check();
+        pingIntervalId = window.setInterval(check, PING_INTERVAL);
+    });
+}

--- a/test/fixtures/common-tests.js
+++ b/test/fixtures/common-tests.js
@@ -1,5 +1,5 @@
 /*global fixture test document*/
-import ReactSelector from '../../';
+import { ReactSelector } from '../../';
 import { loadApp } from '../helpers/service-util';
 import { ClientFunction } from 'testcafe';
 

--- a/test/fixtures/server-rendering.js
+++ b/test/fixtures/server-rendering.js
@@ -1,14 +1,11 @@
-/*global fixture test*/
-import ReactSelector from '../../';
-import { ClientFunction } from 'testcafe';
+/*global fixture test document*/
+import { ReactSelector, waitForReact } from '../../';
 
 fixture `Server rendering`
     .page `http://localhost:1355/serverRender`
-    .beforeEach(async t => {
+    .beforeEach(async () => {
         //NOTE: wait for client side initialization
-        await ClientFunction(() => {
-        })();
-        await t.wait(500);
+        await waitForReact({ selectReactRoot: () => document.querySelector('#__next') });
     });
 
 test('Should get component inside server rendered root node (React 16) - GH-69', async t => {

--- a/test/fixtures/typescript.ts
+++ b/test/fixtures/typescript.ts
@@ -1,5 +1,5 @@
 /*global fixture test*/
-import ReactSelector from '../../';
+import { ReactSelector } from '../../';
 import { loadApp } from '../helpers/service-util';
 
 const REACT_VERSION = 15;

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -6,7 +6,11 @@ declare global {
     }
 }
 
-declare function ReactSelector(selector:string):Selector
+export function ReactSelector(selector:string):Selector
 
-export default ReactSelector;
+interface waitForReactOptions {
+    waitTimeout?:number;
+    selectReactRoot?: () => any;
+}
 
+export function waitForReact(options: waitForReactOptions): any;


### PR DESCRIPTION
With SSR (next.js) ReactSelector sometimes throws an error due to the fact, that the react version detection already runs before react-dom rehydration is complete and `_reactRootContainer` isn't set yet. 

According to your `testcafe-angular-selectors` I created a `waitForReact` helper to wait for `_reactRootContainer` being set on the react root component.  