### PR TITLE
Allow optional argument for boundTestRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ fixture `App tests`
 
 Default timeout for `waitForReact` is `10000` ms. You can specify a custom timeout value - `waitForReact(5000)`.
 
+If you need to call a selector from a Node.js callback, assign the current test controller to the boundTestRun option which is the second argument in the `waitForReact` function - `waitForReact(5000, testController)`. 
+
+If you are getting an error similar to the following: `ClientFunction cannot implicitly resolve the test run in context of which it should be executed.`, then it is likely you will need to pass the testController in this way. See the TestCafe documentation for further details about this issue.
+
 ### Creating selectors for ReactJS components
 
 `ReactSelector` allows you to select page elements by the name of the component class or the nested component element.

--- a/src/wait-for-react.js
+++ b/src/wait-for-react.js
@@ -1,7 +1,7 @@
 /*global ClientFunction document NodeFilter*/
 
 /*eslint-disable no-unused-vars*/
-function waitForReact (timeout) {
+function waitForReact (timeout, testController) {
     /*eslint-enable no-unused-vars*/
     const DEFAULT_TIMEOUT = 1e4;
     const checkTimeout    = typeof timeout === 'number' ? timeout : DEFAULT_TIMEOUT;
@@ -57,5 +57,5 @@ function waitForReact (timeout) {
                 reject('waitForReact: The waiting timeout is exceeded');
             }, checkTimeout);
         });
-    }, { dependencies: { checkTimeout } })();
+    }, { dependencies: { checkTimeout }, boundTestRun: testController })();
 }

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -29,4 +29,4 @@ declare global {
 
 export function ReactSelector(selector: string): Selector
 
-export function waitForReact(timeout?: number): Promise<void>
+export function waitForReact(timeout?: number, testController?: any): Promise<void>


### PR DESCRIPTION
There is an error running waitForReact in a node callback instead of a testcafe test due to the ClientFunction not being able to automatically pick up the testController.

> ClientFunction cannot implicitly resolve the test run in context of which
> it should be executed. If you need to call ClientFunction from the Node.js
> API callback, pass the test controller manually via ClientFunction's
> `.with({ boundTestRun: t })` method first. Note that you cannot execute
> ClientFunction outside the test code.

Here is the issue as described in the testcafe documentation:
https://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors/edge-cases-and-limitations.html#calling-selectors-from-nodejs-callbacks

And by allowing an optional argument to pass in the testController it allows people to fix this issue and use it in different use cases (in my case I am using `gherkin-testcafe`)

Please let me know if you need any more details.