### PR TITLE
React Memo

### DIFF
--- a/src/react-16/index.js
+++ b/src/react-16/index.js
@@ -21,8 +21,8 @@ function react16Selector (selector, parents = rootEls) {
         //react memo
         // it will find the displayName on the elementType if you set it
         if (component.elementType && component.elementType.displayName) return component.elementType.displayName;
-
-
+        
+        
         if (!component.type && !component.memoizedState)
             return null;
 
@@ -66,7 +66,7 @@ function react16Selector (selector, parents = rootEls) {
         //Portal component
         if (!component.child) {
             const portalRoot = component.stateNode && component.stateNode.container &&
-                component.stateNode.container._reactRootContainer;
+                               component.stateNode.container._reactRootContainer;
 
             const rootContainer = portalRoot && (portalRoot._internalRoot || portalRoot);
 
@@ -106,7 +106,7 @@ function react16Selector (selector, parents = rootEls) {
                 throw new Error(`Selector option is expected to be a string, but it was ${typeof compositeSelector}.`);
 
             var selectorIndex = 0;
-            var selectorElms = parseSelectorElements(compositeSelector);
+            var selectorElms  = parseSelectorElements(compositeSelector);
 
             if (selectorElms.length)
                 defineSelectorProperty(selectorElms[selectorElms.length - 1]);
@@ -149,10 +149,7 @@ function react16Selector (selector, parents = rootEls) {
                     if (foundComponents.indexOf(domNode) === -1)
                         foundComponents.push(domNode || createAnnotationForEmptyComponent(reactComponent));
 
-                    window['%testCafeReactFoundComponents%'].push({
-                        node: domNode,
-                        component: reactComponent
-                    });
+                    window['%testCafeReactFoundComponents%'].push({ node: domNode, component: reactComponent });
                 }
 
                 selectorIndex++;

--- a/src/react-16/index.js
+++ b/src/react-16/index.js
@@ -18,6 +18,11 @@ function react16Selector (selector, parents = rootEls) {
     }
 
     function getName (component) {
+        //react memo
+        // it will find the displayName on the elementType if you set it
+        if (component.elementType && component.elementType.displayName) return component.elementType.displayName
+        
+        
         if (!component.type && !component.memoizedState)
             return null;
 

--- a/src/react-16/index.js
+++ b/src/react-16/index.js
@@ -20,9 +20,9 @@ function react16Selector (selector, parents = rootEls) {
     function getName (component) {
         //react memo
         // it will find the displayName on the elementType if you set it
-        if (component.elementType && component.elementType.displayName) return component.elementType.displayName
-        
-        
+        if (component.elementType && component.elementType.displayName) return component.elementType.displayName;
+
+
         if (!component.type && !component.memoizedState)
             return null;
 
@@ -66,7 +66,7 @@ function react16Selector (selector, parents = rootEls) {
         //Portal component
         if (!component.child) {
             const portalRoot = component.stateNode && component.stateNode.container &&
-                               component.stateNode.container._reactRootContainer;
+                component.stateNode.container._reactRootContainer;
 
             const rootContainer = portalRoot && (portalRoot._internalRoot || portalRoot);
 
@@ -106,7 +106,7 @@ function react16Selector (selector, parents = rootEls) {
                 throw new Error(`Selector option is expected to be a string, but it was ${typeof compositeSelector}.`);
 
             var selectorIndex = 0;
-            var selectorElms  = parseSelectorElements(compositeSelector);
+            var selectorElms = parseSelectorElements(compositeSelector);
 
             if (selectorElms.length)
                 defineSelectorProperty(selectorElms[selectorElms.length - 1]);
@@ -149,7 +149,10 @@ function react16Selector (selector, parents = rootEls) {
                     if (foundComponents.indexOf(domNode) === -1)
                         foundComponents.push(domNode || createAnnotationForEmptyComponent(reactComponent));
 
-                    window['%testCafeReactFoundComponents%'].push({ node: domNode, component: reactComponent });
+                    window['%testCafeReactFoundComponents%'].push({
+                        node: domNode,
+                        component: reactComponent
+                    });
                 }
 
                 selectorIndex++;

--- a/test/data/src/app.jsx
+++ b/test/data/src/app.jsx
@@ -251,6 +251,11 @@ class UnfilteredSet_PartialMatching extends React.Component {
     }
 }
 
+const ToMemoize = ({ text }) => <div>{text}</div>;
+const Memoized = React.memo ? React.memo(ToMemoize) : ToMemoize;
+
+Memoized.displayName = 'Memoized';
+
 class App extends React.Component {
     constructor () {
         super();
@@ -290,6 +295,7 @@ class App extends React.Component {
                 <SmartComponent/>
                 <UnfilteredSet/>
                 <UnfilteredSet_PartialMatching/>
+                <Memoized text="Memo" />
             </div>
         );
     }

--- a/test/fixtures/common-tests.js
+++ b/test/fixtures/common-tests.js
@@ -489,6 +489,17 @@ for (const version of SUPPORTED_VERSIONS) {
         });
     });
 
+    test('Should get memoized component', async t => {
+        if (version === 16) {
+            const Memoized = ReactSelector('Memoized');
+            const text = Memoized.getReact(({ props }) => props.text);
+
+            await t
+                .expect(ReactSelector('Memoized').exists).ok()
+                .expect(text).eql('Memo');
+        }
+    });
+
     fixture`ReactJS TestCafe plugin (the app loads during test) (React ${version})`
         .page`http://localhost:1355`;
 


### PR DESCRIPTION
I had issues trying to test memoized arrow components.
The issue was that memoized components have the memo signature and not the original function one.
With this check, ReactSelector will check if the components have a "displayName" set and will use it 
This is good also with minified files. 
You have to manually set a displayName but it's a good practice if you use memoized components