### PR TITLE
Fix tests on IE11 by checking if children variable is defined

### DIFF
--- a/src/react-16/get-root-els.js
+++ b/src/react-16/get-root-els.js
@@ -3,7 +3,7 @@
 /*eslint-disable no-unused-vars*/
 function getRootElsReact16 (el) {
     el = el || document.body;
-    
+
     let rootEls = [];
 
     if (el._reactRootContainer) {
@@ -14,7 +14,7 @@ function getRootElsReact16 (el) {
 
     const children = el.children;
 
-    if (!!children) {
+    if (children) {
         for (let index = 0; index < children.length; ++index) {
             const child = children[index];
 

--- a/src/react-16/get-root-els.js
+++ b/src/react-16/get-root-els.js
@@ -14,10 +14,12 @@ function getRootElsReact16 (el) {
 
     const children = el.children;
 
-    for (let index = 0; index < children.length; ++index) {
-        const child = children[index];
+    if (!!children) {
+        for (let index = 0; index < children.length; ++index) {
+            const child = children[index];
 
-        rootEls = rootEls.concat(getRootElsReact16(child));
+            rootEls = rootEls.concat(getRootElsReact16(child));
+        }
     }
 
     return rootEls;


### PR DESCRIPTION
This PR fixes tests run on IE11 that fail with the following error :
```
An error occurred in Selector code:
TypeError: Unable to get property 'length' of undefined or null
reference
```