### PR TITLE
Fix TypeError while searching for children inside a React.Suspense

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom17": "npm:react-dom@^17.0.0",
     "react16": "npm:react@^16.0.0",
     "react17": "npm:react@^17.0.0",
-    "testcafe": "^1.18.6",
+    "testcafe": "^2.4.0",
     "vite": "^2.9.6"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom17": "npm:react-dom@^17.0.0",
     "react16": "npm:react@^16.0.0",
     "react17": "npm:react@^17.0.0",
-    "testcafe": "^2.4.0",
+    "testcafe": ">=1.18.6",
     "vite": "^2.9.6"
   },
   "scripts": {

--- a/src/react-16-18/index.js
+++ b/src/react-16-18/index.js
@@ -36,7 +36,7 @@ function react16to18Selector (selector, renderedRootIsUnknown, parents = rootEls
             if (component.type.displayName || component.type.name) return component.type.displayName || component.type.name;
         }
 
-        const matches = currentElement.type.toString().match(/^function\s*([^\s(]+)/);
+        const matches = currentElement?.type.toString().match(/^function\s*([^\s(]+)/);
 
         if (matches) return matches[1];
 

--- a/test/data/app/src/AsyncComponent.jsx
+++ b/test/data/app/src/AsyncComponent.jsx
@@ -20,11 +20,8 @@ const fakeLoader = () => {
                 setTimeout(() => {
                     resolve(true)
                 }, 1500);
-            }).then((value) => {
-                console.log('resolved');
-                return value;
             })
-        )
+        );
     }
 
     return cacheValue;

--- a/test/data/app/src/AsyncComponent.jsx
+++ b/test/data/app/src/AsyncComponent.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+function AsyncChild() {
+    return (
+        <div>
+            async child
+        </div>
+    )
+}
+
+let cacheValue = false;
+
+/**
+ * Fake asynchronous call / in-memory cache for suspense testing purposes.
+ */
+const fakeLoader = () => {
+    if (!cacheValue) {
+        cacheValue = (
+            new Promise((resolve) => {
+                setTimeout(() => {
+                    resolve(true)
+                }, 1500);
+            }).then((value) => {
+                console.log('resolved');
+                return value;
+            })
+        )
+    }
+
+    return cacheValue;
+};
+
+export default function AsyncComponent() {
+    const value = use(fakeLoader())
+
+    return (
+        <div>
+            async parent
+            {value && <AsyncChild />}
+        </div>
+    );
+}
+
+// use example for throwing promises to simulate async fetching
+// Source - Facebook's codesandbox on React Suspense Docs:
+//  https://react.dev/reference/react/Suspense
+// @see https://codesandbox.io/s/s9zlw3
+function use(promise) {
+    if (promise.status === 'fulfilled') {
+        return promise.value;
+    } else if (promise.status === 'rejected') {
+        throw promise.reason;
+    } else if (promise.status === 'pending') {
+        throw promise;
+    } else {
+        promise.status = 'pending';
+        promise.then(
+            result => {
+                promise.status = 'fulfilled';
+                promise.value = result;
+            },
+            reason => {
+                promise.status = 'rejected';
+                promise.reason = reason;
+            },
+        );
+        throw promise;
+    }
+}

--- a/test/data/app/src/app.jsx
+++ b/test/data/app/src/app.jsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { Suspense } from 'react';
+
+const AsyncComponent = React.lazy(() => import('./AsyncComponent'));
 
 /*global React ReactDOM*/
 
@@ -229,6 +231,9 @@ export class App extends React.Component {
               <UnfilteredSet_PartialMatching/>
               <Memoized text="Memo" />
               <div id="nestedapp-container"></div>
+              <Suspense fallback={<>loading</>}>
+                  <AsyncComponent />
+              </Suspense>
           </div>
       );
   }

--- a/test/fixtures/common-tests.js
+++ b/test/fixtures/common-tests.js
@@ -511,7 +511,7 @@ for (const version of SUPPORTED_VERSIONS) {
             .expect(ReactSelector('NestedApp Stateless1').withText('Inside nested app').exists).ok();
     });
 
-    test.only('Should find children of a React.Suspense', async t => {
+    test('Should find children of a React.Suspense', async t => {
         if (version !== 18) return;
         await t.expect(ReactSelector('AsyncChild').exists).ok();
     });

--- a/test/fixtures/common-tests.js
+++ b/test/fixtures/common-tests.js
@@ -511,6 +511,11 @@ for (const version of SUPPORTED_VERSIONS) {
             .expect(ReactSelector('NestedApp Stateless1').withText('Inside nested app').exists).ok();
     });
 
+    test.only('Should find children of a React.Suspense', async t => {
+        if (version !== 18) return;
+        await t.expect(ReactSelector('AsyncChild').exists).ok();
+    });
+
     fixture`ReactJS TestCafe plugin (the app loads during test) (React ${version})`
         .page`http://localhost:3000`;
 


### PR DESCRIPTION
Hello!

While working on an upgrade to React 18 we were running into some issues with the results of components / bundles loaded via Suspense. After spending a decent amount of time I tracked it down to this repo and a property being accessed that may not exist _yet_. I also bumped the testcafe version in the package.json to fix build errors with TypeScript, and just have the latest version tested against.

## The Bug: 

When attempting to find a child of a Suspense, the element for the requested selector inside a `ReactSelector` may not exist yet, which throws the following error: 

```
 1) An error occurred in Selector code:
      
      TypeError: Cannot read properties of undefined (reading 'type')
```

## The Fix:
I tracked it down to the `getName` function, and have adding a [previously] failing test case, and a fix in the form of an optional chain when accessing that property.

`currentElement.type => currentElement?.type`

Let me know if I missed something or if I can help provide a better example. Thanks!