### PR TITLE
fix: added another check for component props

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-dom17": "npm:react-dom@^17.0.0",
     "react16": "npm:react@^16.0.0",
     "react17": "npm:react@^17.0.0",
-    "testcafe": "^1.18.6",
+    "testcafe": ">=1.18.6",
     "vite": "^2.9.6"
   },
   "scripts": {

--- a/src/index.js.mustache
+++ b/src/index.js.mustache
@@ -120,6 +120,8 @@ exports.ReactSelector = Selector(selector => {
         }
 
         function componentHasProps ({ props }, filterProps, exactObjectMatch) {
+             if (!props) return false;
+
              for (const prop of Object.keys(filterProps)) {
                  if (!props.hasOwnProperty(prop)) return false;
 


### PR DESCRIPTION
Closes #196

Please check linked issue to get more information about the problem

---

Required to avoid a TypeError on a subsequent lines for React v18+:

```
TypeError: Cannot read properties of null (reading 'hasOwnProperty')
```