### PR TITLE
fix: next build error with node v23, workaround is to downgrade to 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: DevExpress/testcafe-build-system/actions/prepare@main
         with:
-          node-version: 'latest'
+          node-version: '22'
 
       - run: npm ci --legacy-peer-deps
       - run: npm run test


### PR DESCRIPTION
nextjs has issue with build on Node version 23.
The workaround for now is to use Node version 22.

Error: <w> [webpack.cache.PackFileCacheStrategy] Caching failed for pack: Error: Unable to snapshot resolve dependencies

Issue link: https://github.com/vercel/next.js/issues/47394